### PR TITLE
added a useSubject hook

### DIFF
--- a/src/hooks/index.d.ts
+++ b/src/hooks/index.d.ts
@@ -1,4 +1,5 @@
 import { HandlerFunction, NextFunction } from '../utils'
+import { BehaviorSubject } from 'rxjs'
 
 export type UseEventHook = (event: string, handler?: HandlerFunction) => NextFunction
 export const useEvent: UseEventHook
@@ -47,3 +48,6 @@ export interface IUseTableArgs {
 }
 export type UseTable = (arg: IUseTableArgs) => IUseTableResult
 export const useTable: UseTable
+
+export type UseSubject = <StateType = any>(subject: BehaviorSubject) => [StateType, (state:StateType) => void]
+export const useSubject: UseSubject

--- a/src/hooks/index.d.ts
+++ b/src/hooks/index.d.ts
@@ -49,5 +49,5 @@ export interface IUseTableArgs {
 export type UseTable = (arg: IUseTableArgs) => IUseTableResult
 export const useTable: UseTable
 
-export type UseSubject = <StateType = any>(subject: BehaviorSubject) => [StateType, (state:StateType) => void]
+export type UseSubject = <StateType = any>(subject: BehaviorSubject<StateType>) => [StateType, (state:StateType) => void]
 export const useSubject: UseSubject

--- a/src/hooks/useSubject.js
+++ b/src/hooks/useSubject.js
@@ -5,7 +5,7 @@ export const useSubject = subject => {
   useEffect(() => {
     const sub = subject.pipe(skip(1)).subscribe(s => setState(s))
     return () => sub.unsubscribe()
-  })
+  }, [subject])
   const newSetState = state => subject.next(state)
   return [value, newSetState]
 }

--- a/src/hooks/useSubject.js
+++ b/src/hooks/useSubject.js
@@ -1,0 +1,11 @@
+import { useState, useEffect } from 'react'
+import { skip } from 'rxjs/operators'
+export const useSubject = subject => {
+  const [value, setState] = useState(subject.getValue())
+  useEffect(() => {
+    const sub = subject.pipe(skip(1)).subscribe(s => setState(s))
+    return () => sub.unsubscribe()
+  })
+  const newSetState = state => subject.next(state)
+  return [value, newSetState]
+}


### PR DESCRIPTION
Makes it easy to subscribe to an rxjs `BehaviorSubject` and also returns a modified `setState` function that calls `subject.next()`, which makes it easy to drop in as a replacement for useState when another component needs access to the state.