### PR TITLE
added a suite of hooks to support working with rxjs subjects

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dayjs": "^1.8.15",
     "draft-js": "^0.11.0",
     "draftjs-to-html": "^0.8.4",
+    "fast-deep-equal": "^2.0.1",
     "html-to-draftjs": "^1.4.0",
     "lodash": "^4.17.15",
     "office-ui-fabric-react": "^7.28.0",

--- a/src/hooks/index.d.ts
+++ b/src/hooks/index.d.ts
@@ -53,34 +53,36 @@ export interface UsableSubject<StateType = any> {
   value:StateType
   subscribe (observer:(value:StateType) => void): Subscription
 }
-export type UseSubject = <StateType = any>(subject: UsableSubject<StateType>) => [StateType, (state:StateType) => void]
-export const useSubject: UseSubject
-export type UseSub = <StateType = any>(subject: UsableSubject<StateType>) => StateType
-export const useSub: UseSub
-export type UseSubFromContext = <StateType = any>(context: Context<UsableSubject<StateType>>) => StateType
-export const useSubFromContext: UseSubFromContext
-export type UseDerivedSubject =
-  <DerivedType = any, StateType = any> (
-    subject:UsableSubject<StateType>,
-    transform:DerivedSubjectTransform<StateType, DerivedType>,
-    mutate:DerivedSubjectMutate<StateType, DerivedType>
-  ) => [DerivedType, (state:StateType) => void]
-export const useDerivedSubject: UseDerivedSubject
-export type UseDerivedSubjectFromContext =
-  <DerivedType = any, StateType = any> (
-    context:Context<UsableSubject<StateType>>,
-    transform:DerivedSubjectTransform<StateType, DerivedType>,
-    mutate:DerivedSubjectMutate<StateType, DerivedType>
-  ) => [DerivedType, (state:StateType) => void]
-export const useDerivedSubject: UseDerivedSubject
-export type UseDerivedSub =
-  <DerivedType = any, StateType = any> (
-    subject:UsableSubject<StateType>,
-    transform:DerivedSubjectTransform<StateType, DerivedType>
-  ) => DerivedType
-export const useDerivedSub: UseDerivedSub
-export type UseDerivedSubFromContext =
-  <DerivedType = any, StateType = any> (
-    context:Context<UsableSubject<StateType>>,
-    transform:DerivedSubjectTransform<StateType, DerivedType>
-  ) => DerivedType
+export function useSubject <StateType = any>(subject: UsableSubject<StateType>): [StateType, (state:StateType) => void]
+export function useSub <StateType = any>(subject: UsableSubject<StateType>): StateType
+export function useSubFromContext <StateType = any>(context: Context<UsableSubject<StateType>>): StateType
+
+export function useDerivedSubject <DerivedType = any, StateType = any> (
+  subject:UsableSubject<StateType>,
+  transform:DerivedSubjectTransform<StateType, DerivedType>,
+  mutate:DerivedSubjectMutate<StateType, DerivedType>
+): [DerivedType, (state:StateType) => void]
+export function useDerivedSubject <DerivedType = any, StateType = any> (
+  subject:UsableSubject<StateType>,
+  accessor:string,
+): [DerivedType, (state:StateType) => void]
+
+export function useDerivedSubjectFromContext <DerivedType = any, StateType = any> (
+  context:Context<UsableSubject<StateType>>,
+  transform:DerivedSubjectTransform<StateType, DerivedType>,
+  mutate:DerivedSubjectMutate<StateType, DerivedType>
+): [DerivedType, (state:StateType) => void]
+export function useDerivedSubjectFromContext <DerivedType = any, StateType = any> (
+  context:Context<UsableSubject<StateType>>,
+  accessor:string
+): [DerivedType, (state:StateType) => void]
+
+export function useDerivedSub <DerivedType = any, StateType = any> (
+  subject:UsableSubject<StateType>,
+  transform:DerivedSubjectTransform<StateType, DerivedType>
+): DerivedType
+
+export function UseDerivedSubFromContext <DerivedType = any, StateType = any> (
+  context:Context<UsableSubject<StateType>>,
+  transform:DerivedSubjectTransform<StateType, DerivedType>
+): DerivedType

--- a/src/hooks/index.d.ts
+++ b/src/hooks/index.d.ts
@@ -1,5 +1,7 @@
-import { HandlerFunction, NextFunction } from '../utils'
-import { BehaviorSubject } from 'rxjs'
+import { HandlerFunction, NextFunction, DerivedSubjectTransform } from '../utils'
+import { BehaviorSubject, Subject, Subscription } from 'rxjs'
+import { Context } from 'react'
+import { DerivedSubject } from '../utils'
 
 export type UseEventHook = (event: string, handler?: HandlerFunction) => NextFunction
 export const useEvent: UseEventHook
@@ -48,7 +50,24 @@ export interface IUseTableArgs {
 export type UseTable = (arg: IUseTableArgs) => IUseTableResult
 export const useTable: UseTable
 
-export type UseSubject = <StateType = any>(subject: BehaviorSubject<StateType>) => [StateType, (state:StateType) => void]
+export interface UsableSubject<StateType = any> {
+  value:StateType
+  subscribe (observer:(value:StateType) => void): Subscription
+}
+export type UseSubject = <StateType = any>(subject: UsableSubject<StateType>) => [StateType, (state:StateType) => void]
 export const useSubject: UseSubject
-export type UseSub = <StateType = any>(subject: BehaviorSubject<StateType>) => StateType
+export type UseSub = <StateType = any>(subject: UsableSubject<StateType>) => StateType
 export const useSub: UseSub
+export type UseSubFromContext = <StateType = any>(context: Context<UsableSubject<StateType>>) => StateType
+export const useSubFromContext: UseSubFromContext
+export type UseDerivedSub =
+  <DerivedType = any, StateType = any> (
+    subject:UsableSubject<StateType>,
+    transform:DerivedSubjectTransform<StateType, DerivedType>
+  ) => DerivedType
+export const useDerivedSub: UseDerivedSub
+export type UseDerivedSubFromContext =
+  <DerivedType = any, StateType = any> (
+    context:Context<UsableSubject<StateType>>,
+    transform:DerivedSubjectTransform<StateType, DerivedType>
+  ) => DerivedType

--- a/src/hooks/index.d.ts
+++ b/src/hooks/index.d.ts
@@ -66,6 +66,13 @@ export type UseDerivedSubject =
     mutate:DerivedSubjectMutate<StateType, DerivedType>
   ) => [DerivedType, (state:StateType) => void]
 export const useDerivedSubject: UseDerivedSubject
+export type UseDerivedSubjectFromContext =
+  <DerivedType = any, StateType = any> (
+    context:Context<UsableSubject<StateType>>,
+    transform:DerivedSubjectTransform<StateType, DerivedType>,
+    mutate:DerivedSubjectMutate<StateType, DerivedType>
+  ) => [DerivedType, (state:StateType) => void]
+export const useDerivedSubject: UseDerivedSubject
 export type UseDerivedSub =
   <DerivedType = any, StateType = any> (
     subject:UsableSubject<StateType>,

--- a/src/hooks/index.d.ts
+++ b/src/hooks/index.d.ts
@@ -1,7 +1,6 @@
-import { HandlerFunction, NextFunction, DerivedSubjectTransform } from '../utils'
+import { HandlerFunction, NextFunction, DerivedSubjectTransform, DerivedSubjectMutate } from '../utils'
 import { BehaviorSubject, Subject, Subscription } from 'rxjs'
 import { Context } from 'react'
-import { DerivedSubject } from '../utils'
 
 export type UseEventHook = (event: string, handler?: HandlerFunction) => NextFunction
 export const useEvent: UseEventHook
@@ -60,6 +59,13 @@ export type UseSub = <StateType = any>(subject: UsableSubject<StateType>) => Sta
 export const useSub: UseSub
 export type UseSubFromContext = <StateType = any>(context: Context<UsableSubject<StateType>>) => StateType
 export const useSubFromContext: UseSubFromContext
+export type UseDerivedSubject =
+  <DerivedType = any, StateType = any> (
+    subject:UsableSubject<StateType>,
+    transform:DerivedSubjectTransform<StateType, DerivedType>,
+    mutate:DerivedSubjectMutate<StateType, DerivedType>
+  ) => [DerivedType, (state:StateType) => void]
+export const useDerivedSubject: UseDerivedSubject
 export type UseDerivedSub =
   <DerivedType = any, StateType = any> (
     subject:UsableSubject<StateType>,

--- a/src/hooks/useSubject.js
+++ b/src/hooks/useSubject.js
@@ -26,6 +26,11 @@ export const useDerivedSubject = (subject, transform, mutate) => {
   return useSubject(derived)
 }
 
+export const useDerivedSubjectFromContext = (context, transform, mutate) => {
+  const subject = useContext(context)
+  return useDerivedSubject(subject, transform, mutate)
+}
+
 export const useDerivedSub = (subject, transform) => {
   const derived = useMemo(() => new DerivedSubject(subject, transform), [subject, transform.toString()])
   return useSub(derived)

--- a/src/hooks/useSubject.js
+++ b/src/hooks/useSubject.js
@@ -22,7 +22,10 @@ export const useSubFromContext = context => {
 }
 
 export const useDerivedSubject = (subject, transform, mutate) => {
-  const derived = useMemo(() => new DerivedSubject(subject, transform, mutate), [subject, transform.toString(), mutate.toString()])
+  const derived = useMemo(() => new DerivedSubject(subject, transform, mutate), [subject, transform.toString(), (mutate || '').toString()])
+  useEffect(() => {
+    return () => derived.complete()
+  }, [derived])
   return useSubject(derived)
 }
 
@@ -33,6 +36,9 @@ export const useDerivedSubjectFromContext = (context, transform, mutate) => {
 
 export const useDerivedSub = (subject, transform) => {
   const derived = useMemo(() => new DerivedSubject(subject, transform), [subject, transform.toString()])
+  useEffect(() => {
+    return () => derived.complete()
+  }, [derived])
   return useSub(derived)
 }
 

--- a/src/hooks/useSubject.js
+++ b/src/hooks/useSubject.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext, useMemo, useCallback } from 'react'
+import { useState, useEffect, useContext, useMemo } from 'react'
 import { DerivedSubject } from '../utils/DerivedSubject'
 import { skip } from 'rxjs/operators'
 export const useSubject = subject => {
@@ -21,9 +21,13 @@ export const useSubFromContext = context => {
   return useSub(subject)
 }
 
+export const useDerivedSubject = (subject, transform, mutate) => {
+  const derived = useMemo(() => new DerivedSubject(subject, transform, mutate), [subject, transform.toString(), mutate.toString()])
+  return useSubject(derived)
+}
+
 export const useDerivedSub = (subject, transform) => {
-  const derivedtransform = useCallback(transform)
-  const derived = useMemo(() => new DerivedSubject(subject, derivedtransform), [subject, derivedtransform])
+  const derived = useMemo(() => new DerivedSubject(subject, transform), [subject, transform.toString()])
   return useSub(derived)
 }
 

--- a/src/stories/useSubject.stories.jsx
+++ b/src/stories/useSubject.stories.jsx
@@ -1,26 +1,66 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { BehaviorSubject } from 'rxjs'
-import { useSubject } from '../hooks'
+import { useSubject, useDerivedSub, useSubFromContext } from '../hooks'
 import { Button } from '../components'
 
-const CounterSubject = new BehaviorSubject(0)
+const counterSubject = new BehaviorSubject(0)
 function increment () {
-  CounterSubject.next(CounterSubject.getValue() + 1)
+  counterSubject.next(counterSubject.getValue() + 1)
 }
 
 const SubjectExample = (props) => {
-  const [counterValue] = useSubject(CounterSubject)
+  const [counterValue] = useSubject(counterSubject)
+  console.log('rendering')
   return (<div style={{ marginBottom: '10px' }}>
-    <Button label={counterValue} onClick={increment} />
+    <Button label={String(counterValue)} onClick={increment} />
   </div>)
 }
 
 storiesOf('Hooks|useSubject', module)
-  .add('paired buttons', () => {
+  .add('simple', () => {
     return <React.Fragment>
       <SubjectExample />
       <SubjectExample />
       <div>Clicking either button should increment both.</div>
+    </React.Fragment>
+  })
+
+const ExampleContext = React.createContext()
+const ContextExample = (props) => {
+  const counterValue = useSubFromContext(ExampleContext)
+  console.log('rendering')
+  return (<div style={{ marginBottom: '10px' }}>
+    <Button label={String(counterValue)} onClick={increment} />
+  </div>)
+}
+
+storiesOf('Hooks|useSubject', module)
+  .add('context', () => {
+    return <ExampleContext.Provider value={counterSubject}>
+      <ContextExample />
+      <ContextExample />
+      <div>Clicking either button should increment both.</div>
+    </ExampleContext.Provider>
+  })
+
+const parentSubject = new BehaviorSubject({ first: 0, second: 0 })
+const incrementOne = which => () => parentSubject.next({ ...parentSubject.value, [which]: parentSubject.value[which] + 1 })
+const DerivedExample = props => {
+  const counterValue = useDerivedSub(parentSubject, counters => counters[props.which])
+  console.log('rendering', props.which)
+  return (<div style={{ marginBottom: '10px' }}>
+    <Button label={String(counterValue)} onClick={incrementOne(props.which)} />
+  </div>)
+}
+
+storiesOf('Hooks|useSubject', module)
+  .add('derivation', () => {
+    return <React.Fragment>
+      <DerivedExample which='first' />
+      <DerivedExample which='first' />
+      <DerivedExample which='second' />
+      <DerivedExample which='second' />
+      <div>Top two buttons and bottom two buttons should be linked.</div>
     </React.Fragment>
   })

--- a/src/stories/useSubject.stories.jsx
+++ b/src/stories/useSubject.stories.jsx
@@ -66,3 +66,22 @@ storiesOf('Hooks|useSubject', module)
       <div>Top two buttons and bottom two buttons should be linked.</div>
     </React.Fragment>
   })
+
+const AccessorExample = props => {
+  const [counterValue, setCounter] = useDerivedSubject(parentSubject, props.which)
+  console.log('rendering', props.which)
+  return (<div style={{ marginBottom: '10px' }}>
+    <Button label={String(counterValue)} onClick={() => setCounter(counterValue + 1)} />
+  </div>)
+}
+
+storiesOf('Hooks|useSubject', module)
+  .add('accessor', () => {
+    return <React.Fragment>
+      <AccessorExample which='first' />
+      <AccessorExample which='first' />
+      <AccessorExample which='second' />
+      <AccessorExample which='second' />
+      <div>Top two buttons and bottom two buttons should be linked.</div>
+    </React.Fragment>
+  })

--- a/src/stories/useSubject.stories.jsx
+++ b/src/stories/useSubject.stories.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { BehaviorSubject } from 'rxjs'
-import { useSubject, useDerivedSub, useSubFromContext } from '../hooks'
+import { useSubject, useDerivedSubject, useSubFromContext } from '../hooks'
 import { Button } from '../components'
 
 const counterSubject = new BehaviorSubject(0)
@@ -45,12 +45,14 @@ storiesOf('Hooks|useSubject', module)
   })
 
 const parentSubject = new BehaviorSubject({ first: 0, second: 0 })
-const incrementOne = which => () => parentSubject.next({ ...parentSubject.value, [which]: parentSubject.value[which] + 1 })
 const DerivedExample = props => {
-  const counterValue = useDerivedSub(parentSubject, counters => counters[props.which])
+  const [counterValue, setCounter] = useDerivedSubject(parentSubject,
+    counters => counters[props.which],
+    (value, counters) => ({ ...counters, [props.which]: value })
+  )
   console.log('rendering', props.which)
   return (<div style={{ marginBottom: '10px' }}>
-    <Button label={String(counterValue)} onClick={incrementOne(props.which)} />
+    <Button label={String(counterValue)} onClick={() => setCounter(counterValue + 1)} />
   </div>)
 }
 

--- a/src/utils/DerivedSubject.js
+++ b/src/utils/DerivedSubject.js
@@ -1,4 +1,5 @@
 import { BehaviorSubject } from 'rxjs'
+import { skip } from 'rxjs/operators'
 import equal from 'fast-deep-equal'
 
 export class DerivedSubject extends BehaviorSubject {
@@ -6,7 +7,7 @@ export class DerivedSubject extends BehaviorSubject {
     super(transform(subject.value))
     this.parentSubject = subject
     this.mutate = mutate
-    subject.subscribe(newval => {
+    subject.pipe(skip(1)).subscribe(newval => {
       const newderived = transform(newval)
       if (!equal(newderived, this.value)) {
         super.next(newderived)

--- a/src/utils/DerivedSubject.js
+++ b/src/utils/DerivedSubject.js
@@ -1,13 +1,20 @@
 import { BehaviorSubject } from 'rxjs'
 import { skip } from 'rxjs/operators'
 import equal from 'fast-deep-equal'
+import get from 'lodash/get'
+import set from 'lodash/set'
 
 export class DerivedSubject extends BehaviorSubject {
   constructor (subject, transform, mutate) {
+    if (typeof transform === 'string') {
+      const accessor = transform
+      transform = parentValue => get(parentValue, accessor)
+      mutate = (value, parentValue) => set(parentValue, accessor, value)
+    }
     super(transform(subject.value))
     this.parentSubject = subject
     this.mutate = mutate
-    subject.pipe(skip(1)).subscribe(newval => {
+    this.subscription = subject.pipe(skip(1)).subscribe(newval => {
       const newderived = transform(newval)
       if (!equal(newderived, this.value)) {
         super.next(newderived)
@@ -17,5 +24,10 @@ export class DerivedSubject extends BehaviorSubject {
 
   next (value) {
     if (this.mutate) this.parentSubject.next(this.mutate(value, this.parentSubject.value))
+  }
+
+  complete () {
+    this.subscription.unsubscribe()
+    super.complete()
   }
 }

--- a/src/utils/DerivedSubject.js
+++ b/src/utils/DerivedSubject.js
@@ -1,0 +1,20 @@
+import { BehaviorSubject } from 'rxjs'
+import equal from 'fast-deep-equal'
+
+export class DerivedSubject extends BehaviorSubject {
+  constructor (subject, transform, mutate) {
+    super(transform(subject.value))
+    this.parentSubject = subject
+    this.mutate = mutate
+    subject.subscribe(newval => {
+      const newderived = transform(newval)
+      if (!equal(newderived, this.value)) {
+        super.next(newderived)
+      }
+    })
+  }
+
+  next (value) {
+    if (this.mutate) this.parentSubject.next(this.mutate(value, this.parentSubject.value))
+  }
+}

--- a/src/utils/index.d.ts
+++ b/src/utils/index.d.ts
@@ -14,7 +14,8 @@ export interface ISubject {
 export const Subject: ISubject
 
 export type DerivedSubjectTransform = <InputType, OutputType>(input:InputType) => OutputType
+export type DerivedSubjectMutate = <InputType, OutputType>(value:OutputType, parentValue:InputType) => InputType
 export interface IDerivedSubject<OutputType = any, InputType = any> extends BehaviorSubject<InputType> {
-  new (subject:UsableSubject, transform:DerivedSubjectTransform<InputType, OutputType>): IDerivedSubject<OutputType, InputType>
+  new (subject:UsableSubject<OutputType>, transform:DerivedSubjectTransform<InputType, OutputType>, mutate?: DerivedSubjectMutate<InputType, OutputType>): IDerivedSubject<OutputType, InputType>
 }
 export const DerivedSubject:IDerivedSubject

--- a/src/utils/index.d.ts
+++ b/src/utils/index.d.ts
@@ -16,6 +16,7 @@ export const Subject: ISubject
 export type DerivedSubjectTransform = <InputType, OutputType>(input:InputType) => OutputType
 export type DerivedSubjectMutate = <InputType, OutputType>(value:OutputType, parentValue:InputType) => InputType
 export interface IDerivedSubject<OutputType = any, InputType = any> extends BehaviorSubject<InputType> {
+  new (subject:UsableSubject<OutputType>, accessor:string): IDerivedSubject<OutputType, InputType>
   new (subject:UsableSubject<OutputType>, transform:DerivedSubjectTransform<InputType, OutputType>, mutate?: DerivedSubjectMutate<InputType, OutputType>): IDerivedSubject<OutputType, InputType>
 }
 export const DerivedSubject:IDerivedSubject

--- a/src/utils/index.d.ts
+++ b/src/utils/index.d.ts
@@ -1,3 +1,6 @@
+import { BehaviorSubject } from "rxjs"
+import { UsableSubject } from "../hooks"
+
 export type HandlerFunction = (...args: any[]) => void
 export type SubscribeFunction = (event: string, handler: HandlerFunction) => void
 export type UnsubscribeFunction = (event: string, handler: HandlerFunction) => void
@@ -8,5 +11,10 @@ export interface ISubject {
   unsubscribe: UnsubscribeFunction
   next: NextFunction
 }
-
 export const Subject: ISubject
+
+export type DerivedSubjectTransform = <InputType, OutputType>(input:InputType) => OutputType
+export interface IDerivedSubject<OutputType = any, InputType = any> extends BehaviorSubject<InputType> {
+  new (subject:UsableSubject, transform:DerivedSubjectTransform<InputType, OutputType>): IDerivedSubject<OutputType, InputType>
+}
+export const DerivedSubject:IDerivedSubject

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,1 +1,2 @@
 export * from './Subject'
+export * from './DerivedSubject'


### PR DESCRIPTION
* Added `useSubFromContext` as a convenience for pulling a subject from context API. 
* Added `DerivedSubject`, a BehaviorSubject that efficiently transforms and emits another BehaviorSubject's state. 
* Added convenience hooks for creating a DerivedSubject as needed: `useDerivedSub` and `useDerivedSubFromContext`.
* Added stories demonstrating/testing the new additions.