### PR TITLE
Forward ref for dropdown component

### DIFF
--- a/src/components/Form/Dropdown/Dropdown.js
+++ b/src/components/Form/Dropdown/Dropdown.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import { initializeIcons } from 'office-ui-fabric-react/lib/Icons'
 initializeIcons()
 
-export const Dropdown = props => {
+export const Dropdown = React.forwardRef((props, ref) => {
   const { label, options, path, initialSelectedKey, disabled, styles } = props
 
   const {
@@ -20,6 +20,7 @@ export const Dropdown = props => {
 
   return (
     <ComboBox
+      ref={ref}
       styles={styles}
       disabled={disabled}
       selectedKey={value.key}
@@ -31,7 +32,7 @@ export const Dropdown = props => {
       useComboBoxAsMenuWidth
     />
   )
-}
+})
 
 Dropdown.defaultProps = {
   options: []

--- a/src/components/Form/Dropdown/index.d.ts
+++ b/src/components/Form/Dropdown/index.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import * as React from 'react'
 import { IComboBoxStyles } from 'office-ui-fabric-react/lib/ComboBox'
 
 export interface DropdownOptions {
@@ -7,6 +7,7 @@ export interface DropdownOptions {
 }
 
 export interface DropdownProps {
+  ref?: React.MutableRefObject<HTMLInputElement | undefined>
   label: string;
   path: string;
   options?: DropdownOptions[];
@@ -15,5 +16,4 @@ export interface DropdownProps {
   initialSelectedKey?: string;
 }
 
-export const Dropdown: React.FC<DropdownProps>;
-
+export const Dropdown: React.FC<DropdownProps>


### PR DESCRIPTION
Adding this because I need access to call .focus() on the input.