### PR TITLE
remove centerComponent from material-ui BaseModal

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -16,7 +16,6 @@ export const Modal = props => {
       aria-describedby={props.ariaDescription}
       open={props.isOpen}
       onClose={props.onClose}
-      centerContent={props.centerContent}
       closeAfterTransition
       disableAutoFocus={props.disableEnforceFocus}
       disableEnforceFocus={props.disableEnforceFocus}


### PR DESCRIPTION
It does not have such a prop and it is throwing in console. I think it's left over code.