### PR TITLE
Adding an updatePath function to the Form ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "scripts": {
     "prepublish": "yarn build",
+    "postpublish": "git push",
     "build": "rm -rf lib/ && npx babel src/ -d lib/ --copy-files && rm -rf lib/stories",
     "storybook": "start-storybook -p 9009 -s public",
     "build-storybook": "build-storybook -s public",

--- a/src/components/Form/index.d.ts
+++ b/src/components/Form/index.d.ts
@@ -1,7 +1,8 @@
-import * as React from 'react';
+import * as React from 'react'
 
 export interface IFormRef {
   submit: () => Promise<void>
+  updatePath: (path: string, value: any) => void
 }
 
 export interface FormProps {
@@ -29,11 +30,10 @@ export interface FormProps {
      * Ref of the form, which exposes the submit() version
      */
     ref?: React.MutableRefObject<IFormRef | undefined | null>;
-    /** 
-     * The amount of time to wait, in milliseconds, before calling the validation function 
+    /**
+     * The amount of time to wait, in milliseconds, before calling the validation function
      */
     validationDelay?: number;
 }
 
-export const Form: React.FC<FormProps>;
-
+export const Form: React.FC<FormProps>

--- a/src/hooks/useFormInput.js
+++ b/src/hooks/useFormInput.js
@@ -35,7 +35,15 @@ export const useFormInput = ({ path, extractor, transformer, initialValue }) => 
     setSuccess(successMessage || '')
   }, [setError])
 
+  const handleUpdateState = useCallback(state => {
+    const updatedValue = get(state, path)
+    if (updatedValue !== value) {
+      handleChange({ value: updatedValue, path, inputEvent, transformer })
+    }
+  }, [])
+
   useEvent(`${formEvent}-form-ready`, handleFormReady)
+  useEvent(`${formEvent}-update-state`, handleUpdateState)
   useEvent(`${formEvent}-validate-result`, handleValidation)
 
   const updateFormValue = useCallback((value) => {

--- a/src/stories/Form.stories.jsx
+++ b/src/stories/Form.stories.jsx
@@ -149,7 +149,27 @@ const FormExample = props => {
   )
 }
 
+const PathUpdateForm = () => {
+  const form = useRef()
+  return (
+    <Stack spacing={12}>
+      <Form
+        onChange={({ form }) => console.log(form.name)}
+        onSubmit={({ form }) => console.log(form)}
+        ref={form}
+      >
+        <StyledInput label='Name' path='name' />
+        <Button type='submit' label='Submit' />
+      </Form>
+      <Button label='Update Name' onClick={() => form.current.updatePath('name', 'Andrew')} />
+    </Stack>
+  )
+}
+
 storiesOf('Form|Simple', module)
   .add('basic', () => {
     return <FormExample />
+  })
+  .add('path updates', () => {
+    return <PathUpdateForm />
   })


### PR DESCRIPTION
This allows the user of the form to call `updatePath(path, value)` to trigger a manual update of an input in the form.