### PR TITLE
Indexed error updates

### DIFF
--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -83,7 +83,6 @@ export const Form = React.forwardRef((props, ref) => {
         const errorResults = get(results, 'errors')
         const successResults = get(results, 'success')
 
-        console.log('error results', errorResults)
         if (errorResults || successResults) {
           broadcastValidateResults({ errors: errorResults, success: successResults })
         }

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -39,6 +39,7 @@ export const Form = React.forwardRef((props, ref) => {
   const formEvent = useRef(id || uuid())
   const _initialState = useRef(initialValues || {})
   const firstValidationSkipped = useRef(false)
+  const childCount = useRef(0)
 
   const [form, formDispatch] = useReducer(immutableReducer, _initialState.current)
   const [errors, errorDispatch] = useReducer(immutableReducer, {})
@@ -54,10 +55,16 @@ export const Form = React.forwardRef((props, ref) => {
     Subject.next(inputEvent, value)
   }, [formDispatch])
 
-  const broadcastValidateResults = useCallback(useEvent(`${formEvent.current}-validate-result`), [])
-  const notifyChildrenReady = useCallback(useEvent(`${formEvent.current}-form-ready`), [])
-  const updateChildState = useCallback(useEvent(`${formEvent.current}-update-state`), [])
+  const broadcastValidateResults = useEvent(`${formEvent.current}-validate-result`)
+  const notifyChildrenReady = useEvent(`${formEvent.current}-form-ready`)
+  const updateChildState = useEvent(`${formEvent.current}-update-state`)
 
+  const handleChildRegister = useCallback((inputEvent) => {
+    childCount.current += 1
+    Subject.next(`${inputEvent}-update-index`, childCount.current)
+  }, [])
+
+  useEvent(`${formEvent.current}-register-self`, handleChildRegister)
   useEvent(`${formEvent.current}-data`, handleChildData)
 
   useEffect(() => {

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -62,6 +62,7 @@ export const Form = React.forwardRef((props, ref) => {
   const broadcastValidateResults = useEvent(`${formEvent.current}-validate-result`)
   const notifyChildrenReady = useEvent(`${formEvent.current}-form-ready`)
   const updateChildState = useEvent(`${formEvent.current}-update-state`)
+  const broadcastIndexCheck = useEvent(`${formEvent.current}-index-check`)
 
   const handleChildRegister = useCallback((inputEvent) => {
     childCount.current += 1
@@ -82,6 +83,7 @@ export const Form = React.forwardRef((props, ref) => {
         const errorResults = get(results, 'errors')
         const successResults = get(results, 'success')
 
+        console.log('error results', errorResults)
         if (errorResults || successResults) {
           broadcastValidateResults({ errors: errorResults, success: successResults })
         }
@@ -89,6 +91,8 @@ export const Form = React.forwardRef((props, ref) => {
         const errors = get(results, 'errors')
         const success = get(results, 'success')
         broadcastValidateResults({ errors, success })
+      } finally {
+        broadcastIndexCheck(childCount.current)
       }
     }
   }, [onSubmit, broadcastValidateResults, form, errors])

--- a/src/hooks/useEvent.js
+++ b/src/hooks/useEvent.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useCallback } from 'react'
 import { Subject } from '../utils'
 
 export const useEvent = (event, handler) => {
@@ -8,5 +8,5 @@ export const useEvent = (event, handler) => {
     return () => Subject.unsubscribe(event, handler)
   }, [event, handler])
 
-  return value => Subject.next(event, value)
+  return useCallback(value => Subject.next(event, value), [event])
 }

--- a/src/hooks/useFormInput.js
+++ b/src/hooks/useFormInput.js
@@ -5,7 +5,6 @@ import uuid from 'uuid/v4'
 import get from 'lodash/get'
 import debounce from 'lodash/debounce'
 
-
 export const useFormInput = ({ path, extractor, transformer, initialValue }) => {
   const formEvent = useContext(FormContext)
   const _id = useRef(uuid())
@@ -80,7 +79,6 @@ export const useFormInput = ({ path, extractor, transformer, initialValue }) => 
       setDirty(true)
     }
   }, [setDirty])
-
 
   useEvent(`${formEvent}-form-ready`, handleFormReady)
   useEvent(`${formEvent}-update-state`, handleUpdateState)

--- a/src/hooks/useFormInput.js
+++ b/src/hooks/useFormInput.js
@@ -1,31 +1,59 @@
-import { useContext, useRef, useState, useEffect, useCallback } from 'react'
+import { useContext, useMemo, useRef, useState, useEffect, useCallback } from 'react'
 import { FormContext } from '../components/Form'
 import { useEvent } from './useEvent'
 import uuid from 'uuid/v4'
-import { get } from 'lodash'
+import get from 'lodash/get'
+import debounce from 'lodash/debounce'
 
 export const useFormInput = ({ path, extractor, transformer, initialValue }) => {
   const formEvent = useContext(FormContext)
   const _id = useRef(uuid())
-  const [value, setValue] = useState(() => {
+  const _index = useRef(null)
+
+  const [value, _setValue] = useState(() => {
     if (initialValue || initialValue === null) return initialValue
     return ''
   })
-  const [error, setError] = useState('')
+  const [_error, setError] = useState('')
   const [success, setSuccess] = useState('')
 
   const [inputEvent, setInputEvent] = useState(`${formEvent}_${_id.current}`)
 
   const [isDirty, setIsDirty] = useState(false)
 
-  const handleChange = useCallback(useEvent(`${formEvent}-data`), [])
+  const setDirty = useCallback(debounce((value) => {
+    if (value !== isDirty) {
+      setIsDirty(value)
+    }
+  }, 400), [setIsDirty, isDirty])
+
+  const setValue = useCallback((updatedValue) => {
+    if (updatedValue !== value) _setValue(updatedValue)
+  }, [_setValue, value])
+
+  const error = useMemo(() => isDirty ? _error : '', [_error, isDirty])
+
+  const _broadcastChange = useEvent(`${formEvent}-data`)
+  const _broadcastIndexCheck = useEvent(`${formEvent}-index-check`)
+
+  const handleChange = useCallback((value) => {
+    _broadcastChange(value)
+    if (!isDirty) {
+      setDirty.cancel()
+      setDirty(true)
+      _broadcastIndexCheck(_index.current)
+    }
+  }, [_broadcastChange, isDirty, setDirty])
+
+  const registerSelf = useEvent(`${formEvent}-register-self`)
 
   const handleFormReady = useCallback((initialState) => {
     const initialValue = get(initialState, path)
     if (initialValue) {
       setValue(initialValue)
     }
-  }, [setValue])
+    registerSelf(inputEvent)
+  }, [setValue, inputEvent, registerSelf])
 
   const handleValidation = useCallback(result => {
     const errorMessage = get(result, `errors.${path}`)
@@ -33,7 +61,7 @@ export const useFormInput = ({ path, extractor, transformer, initialValue }) => 
 
     setError(errorMessage || '')
     setSuccess(successMessage || '')
-  }, [setError])
+  }, [setError, setSuccess])
 
   const handleUpdateState = useCallback(state => {
     const updatedValue = get(state, path)
@@ -42,13 +70,26 @@ export const useFormInput = ({ path, extractor, transformer, initialValue }) => 
     }
   }, [])
 
+  const handleUpdateIndex = useCallback((index) => {
+    _index.current = index
+  }, [])
+
+  const handleIndexCheck = useCallback((index) => {
+    if (_index.current !== null && _index.current <= index && !isDirty) {
+      setDirty(true)
+    }
+  }, [setDirty])
+
+
   useEvent(`${formEvent}-form-ready`, handleFormReady)
   useEvent(`${formEvent}-update-state`, handleUpdateState)
   useEvent(`${formEvent}-validate-result`, handleValidation)
+  useEvent(`${inputEvent}-update-index`, handleUpdateIndex)
+  useEvent(`${formEvent}-index-check`, handleIndexCheck)
 
-  const updateFormValue = useCallback((value) => {
-    setValue(value)
-  }, [setValue])
+  const updateFormValue = useCallback((updatedValue) => {
+    setValue(updatedValue)
+  }, [value, setValue])
 
   useEvent(inputEvent, updateFormValue)
 
@@ -68,8 +109,8 @@ export const useFormInput = ({ path, extractor, transformer, initialValue }) => 
   }, [handleChange, extractor])
 
   const onBlur = useCallback(() => {
-    if (!isDirty) setIsDirty(true)
-  }, [setIsDirty, isDirty])
+    setDirty(true)
+  }, [setDirty])
 
   return {
     onChange: notifyFormValueChange,

--- a/src/stories/Form.stories.jsx
+++ b/src/stories/Form.stories.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useImperativeHandle } from 'react'
+import React, { useRef, useImperativeHandle, useCallback } from 'react'
 import { storiesOf } from '@storybook/react'
 import { Form, Stack, Button, BasePicker, Checkbox } from '../components'
 import { TextInput, RichText, Dropdown, RadioGroup } from '../components/Form/Inputs'
@@ -175,19 +175,22 @@ const PathUpdateForm = () => {
 
 const IndexedErrorForm = () => {
   const form = useRef()
+  const validate = useCallback((form) => {
+    const errors = {}
+    if (!form.one) errors['one'] = 'One is required'
+    if (!form.two) errors['two'] = 'Two is required'
+    if (!form.three) errors['three'] = 'Three is required'
+    if (!form.four) errors['four'] = 'Four is required'
+    if (!form.five) errors['five'] = 'Five is required'
+    return { errors }
+  }, [])
   return (
     <Stack spacing={12}>
       <Form
-        validate={(form) => {
-          const errors = {}
-          if (!form.one) errors['one'] = 'One is required'
-          if (!form.two) errors['two'] = 'Two is required'
-          if (!form.three) errors['three'] = 'Three is required'
-          if (!form.four) errors['four'] = 'Four is required'
-          if (!form.five) errors['five'] = 'Five is required'
-          return { errors }
+        validate={validate}
+        onSubmit={({ form }) => {
+          return validate(form)
         }}
-        onSubmit={({ form }) => console.log(form)}
         ref={form}
       >
         <Stack
@@ -205,8 +208,6 @@ const IndexedErrorForm = () => {
     </Stack>
   )
 }
-
-
 
 storiesOf('Form|Simple', module)
   .add('basic', () => {

--- a/src/stories/Form.stories.jsx
+++ b/src/stories/Form.stories.jsx
@@ -172,7 +172,6 @@ const IndexedErrorForm = () => {
     <Stack spacing={12}>
       <Form
         validate={(form) => {
-          console.log(form)
           const errors = {}
           if (!form.one) errors['one'] = 'One is required'
           if (!form.two) errors['two'] = 'Two is required'

--- a/src/stories/Form.stories.jsx
+++ b/src/stories/Form.stories.jsx
@@ -166,10 +166,49 @@ const PathUpdateForm = () => {
   )
 }
 
+const IndexedErrorForm = () => {
+  const form = useRef()
+  return (
+    <Stack spacing={12}>
+      <Form
+        validate={(form) => {
+          console.log(form)
+          const errors = {}
+          if (!form.one) errors['one'] = 'One is required'
+          if (!form.two) errors['two'] = 'Two is required'
+          if (!form.three) errors['three'] = 'Three is required'
+          if (!form.four) errors['four'] = 'Four is required'
+          if (!form.five) errors['five'] = 'Five is required'
+          return { errors }
+        }}
+        onSubmit={({ form }) => console.log(form)}
+        ref={form}
+      >
+        <Stack
+          style={{ width: 500 }}
+          spacing={12}
+        >
+          <StyledInput label='One' path='one' />
+          <StyledInput label='Two' path='two' />
+          <StyledInput label='Three' path='three' />
+          <StyledInput label='Four' path='four' />
+          <StyledInput label='Five' path='five' />
+          <Button type='submit' label='Submit' />
+        </Stack>
+      </Form>
+    </Stack>
+  )
+}
+
+
+
 storiesOf('Form|Simple', module)
   .add('basic', () => {
     return <FormExample />
   })
   .add('path updates', () => {
     return <PathUpdateForm />
+  })
+  .add('indexed error tracking', () => {
+    return <IndexedErrorForm />
   })


### PR DESCRIPTION
This PR includes three behavior changes:

1. All form elements in a single form component will become dirty based on how far down you've made it in the form. If you start halfway through, all the elements above you should be dirtied.
2. Error messages are only delivered from `useFormInput` when the input is considered dirty.
3. `useEvent` returns a function wrapped in `useCallback` now, which it should've done before.