### PR TITLE
Update store and derivedstore

### DIFF
--- a/src/utils/index.d.ts
+++ b/src/utils/index.d.ts
@@ -22,7 +22,7 @@ export interface IDerivedSubject<OutputType = any, InputType = any> extends Beha
 export const DerivedSubject:IDerivedSubject
 
 export interface IStoreOptions {
-  immutable: boolean
+  immutable?: boolean
 }
 export interface IStore<StateType> extends BehaviorSubject<StateType> {
   new (initialValue:StateType, options?:IStoreOptions): IStore<StateType>

--- a/src/utils/index.d.ts
+++ b/src/utils/index.d.ts
@@ -21,7 +21,12 @@ export interface IDerivedSubject<OutputType = any, InputType = any> extends Beha
 }
 export const DerivedSubject:IDerivedSubject
 
-export interface IStore<StateType> extends BehaviorSubject<StateType> {}
+export interface IStoreOptions {
+  immutable: boolean
+}
+export interface IStore<StateType> extends BehaviorSubject<StateType> {
+  new (initialValue:StateType, options:IStoreOptions): IStore<StateType>
+}
 export interface IDerivedStore<OutputType,InputType> extends IStore<OutputType> {
   new (store:UsableStore<OutputType>, getter:(state:InputType) => OutputType, setter?: (newvalue:OutputType, state:InputType) => InputType): IDerivedStore<OutputType, InputType>
   new <Selector extends keyof InputType>(store:UsableStore<InputType[Selector]>, selector:Selector): IDerivedStore<InputType[Selector], InputType>

--- a/src/utils/index.d.ts
+++ b/src/utils/index.d.ts
@@ -25,7 +25,7 @@ export interface IStoreOptions {
   immutable: boolean
 }
 export interface IStore<StateType> extends BehaviorSubject<StateType> {
-  new (initialValue:StateType, options:IStoreOptions): IStore<StateType>
+  new (initialValue:StateType, options?:IStoreOptions): IStore<StateType>
 }
 export interface IDerivedStore<OutputType,InputType> extends IStore<OutputType> {
   new (store:UsableStore<OutputType>, getter:(state:InputType) => OutputType, setter?: (newvalue:OutputType, state:InputType) => InputType): IDerivedStore<OutputType, InputType>


### PR DESCRIPTION
* updated typescript type to support immutable option
* when given a selector, derived store now uses immutable set so as not to violate parent store's setting to use immutable updates