### PR TITLE
Fix row selector wrapping when using sans serif fonts

### DIFF
--- a/src/components/Table/TableComponents/Pages.js
+++ b/src/components/Table/TableComponents/Pages.js
@@ -49,7 +49,7 @@ export const Pages = props => {
 
   return (
     <PageContainer horizontal horizontalAlign='space-between' verticalAlign='center' spacing={6}>
-      <Stack horizontal horizontalAlign='end' style={{flex: 1}}>
+      <Stack horizontal horizontalAlign='end' style={{ flex: 1 }}>
         {ButtonRow && <ButtonRow />}
       </Stack>
       <Stack horizontal horizontalAlign='end' verticalAlign='center' spacing={6}>

--- a/src/components/Table/TableComponents/RowsPicker.js
+++ b/src/components/Table/TableComponents/RowsPicker.js
@@ -32,6 +32,7 @@ const RowOption = styled.span`
   &:hover {
     background-color: #c4c4c4;
   }
+  white-space: nowrap;
   cursor: pointer;
 `
 
@@ -41,7 +42,7 @@ const DropdownButton = styled.div`
   border-radius: 4px;
   background-color: ${Theme.maroon.hex()};
   margin-right: 8px;
-  padding: 8px 12px;
+  padding: 8px 16px;
   cursor: pointer;
 `
 


### PR DESCRIPTION
![Screen Shot 2020-02-28 at 2 10 06 PM](https://user-images.githubusercontent.com/11399005/75583832-0a8c7d80-5a34-11ea-93ee-606d7139f4ed.png)

This is what it was doing, the spacing on sans serif fonts is bigger maybe? Not sure, I just set the white-space to nowrap.