### PR TITLE
Exposed min and max date error message props

### DIFF
--- a/src/components/BaseDatePicker/BaseDatePicker.js
+++ b/src/components/BaseDatePicker/BaseDatePicker.js
@@ -55,7 +55,7 @@ const datePickerTheme = createMuiTheme({
 })
 
 export const BaseDatePicker = props => {
-  const { value, placeholder, disabled, onChange, mask, format, variant, emptyLabel, label, maxDate, minDate } = props
+  const { value, placeholder, disabled, onChange, mask, format, variant, emptyLabel, label, maxDate, minDate, minDateMessage, maxDateMessage } = props
 
   return (
     <ThemeProvider theme={datePickerTheme}>
@@ -73,6 +73,8 @@ export const BaseDatePicker = props => {
           variant={variant}
           value={value}
           invalidDateMessage=''
+          minDateMessage={minDateMessage || `Date should not be before ${dayjs(minDate).format(format)}`}
+          maxDateMessage={maxDateMessage || `Date should not be after ${dayjs(maxDate).format(format)}`}
           onChange={onChange}
         />
       </MuiPickersUtilsProvider>
@@ -82,8 +84,8 @@ export const BaseDatePicker = props => {
 
 BaseDatePicker.defaultProps = {
   variant: 'dialog',
-  minDate: new Date('1900-01-01'),
-  maxDate: new Date('2100-01-01'),
+  minDate: dayjs('1900-01-01').toDate(),
+  maxDate: dayjs('2100-01-01').toDate(),
   format: 'MM/DD/YYYY',
   mask: '__/__/____',
   placeholder: '10/31/2019'
@@ -93,6 +95,8 @@ BaseDatePicker.propTypes = {
   variant: PropTypes.oneOf(['dialog', 'inline', 'static']),
   minDate: PropTypes.instanceOf(Date),
   maxDate: PropTypes.instanceOf(Date),
+  minDateMessage: PropTypes.string,
+  maxDateMessage: PropTypes.string,
   emptyLabel: PropTypes.string,
   format: PropTypes.string,
   value: PropTypes.instanceOf(dayjs),

--- a/src/components/BaseDatePicker/index.d.ts
+++ b/src/components/BaseDatePicker/index.d.ts
@@ -1,13 +1,15 @@
-import * as React from 'react';
+import * as React from 'react'
 
-import { Dayjs } from 'dayjs';
+import { Dayjs } from 'dayjs'
 
-export type BaseDatePickerVariant = "dialog" | "inline" | "static";
+export type BaseDatePickerVariant = 'dialog' | 'inline' | 'static';
 
 export interface BaseDatePickerProps {
   variant?: BaseDatePickerVariant;
   minDate?: Date;
   maxDate?: Date;
+  minDateMessage?: string;
+  maxDateMessage?: string;
   label?: string;
   emptyLabel?: string;
   format?: string;
@@ -16,5 +18,4 @@ export interface BaseDatePickerProps {
   mask?: string;
 }
 
-export const BaseDatePicker: React.FC<BaseDatePickerProps>;
-
+export const BaseDatePicker: React.FC<BaseDatePickerProps>

--- a/src/components/Form/DatePicker/DatePicker.js
+++ b/src/components/Form/DatePicker/DatePicker.js
@@ -12,6 +12,8 @@ export const DatePicker = props => {
     mask,
     minDate,
     maxDate,
+    minDateMessage,
+    maxDateMessage,
     displayFormat,
     placeholder,
     label,
@@ -46,6 +48,8 @@ export const DatePicker = props => {
       placeholder={placeholder}
       minDate={minDate}
       maxDate={maxDate}
+      minDateMessage={minDateMessage}
+      maxDateMessage={maxDateMessage}
       disabled={disabled}
     />
     <ErrorMessage error={error} success={success} />
@@ -67,6 +71,8 @@ DatePicker.propTypes = {
   variant: PropTypes.oneOf(['dialog', 'inline', 'static']),
   minDate: PropTypes.instanceOf(Date),
   maxDate: PropTypes.instanceOf(Date),
+  minDateMessage: PropTypes.string,
+  maxDateMessage: PropTypes.string,
   initialValue: PropTypes.instanceOf(Date),
   emptyLabel: PropTypes.string,
   displayFormat: PropTypes.string,

--- a/src/components/Form/DatePicker/index.d.ts
+++ b/src/components/Form/DatePicker/index.d.ts
@@ -1,14 +1,16 @@
-import * as React from 'react';
+import * as React from 'react'
 
 type Maybe<T> = T | null
 
-export type DatePickerVariant = "dialog" | "inline" | "static";
+export type DatePickerVariant = 'dialog' | 'inline' | 'static';
 
 export interface DatePickerProps {
   path: string;
   variant?: DatePickerVariant;
   minDate?: Date;
   maxDate?: Date;
+  minDateMessage?: string;
+  maxDateMessage?: string;
   emptyLabel?: string;
   displayFormat?: string;
   format?: string;
@@ -19,5 +21,4 @@ export interface DatePickerProps {
   label?: string
 }
 
-export const DatePicker: React.FC<DatePickerProps>;
-
+export const DatePicker: React.FC<DatePickerProps>

--- a/src/stories/Form.stories.jsx
+++ b/src/stories/Form.stories.jsx
@@ -116,7 +116,7 @@ const FormExample = props => {
           <Checkbox path='agreement' label='I have at least 16 pieces of flair.' />
           <Stack horizontal horizontalAlign='space-between' spacing={12}>
             <div style={{ flex: 1 }}>
-              <DatePicker label='Delivery Date' path='date.delivery' variant='inline' initialValue={null} />
+              <DatePicker label='Delivery Date' path='date.delivery' variant='inline' initialValue={null} minDateMessage='Too soon!' />
             </div>
             <div style={{ flex: 1 }}>
               <DatePicker label='Pickup Date' path='date.pickup' variant='inline' initialValue={dayjs('2017-01-24').toDate()} />


### PR DESCRIPTION
I'm exposing the error messages for dates exceeding their minimum and maximum date ranges. A default is provided.